### PR TITLE
feat: add review budget cadence and checkpoint meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ python pipeline.py --input ./docs --regulatorik gwg --adversarial --skeptiker
 | `--model` | `claude-sonnet-4-5-20250514` | Anthropic-Modell |
 | `--sektionen` | alle | Nur diese Sektionen prüfen (z.B. `S01 S02`) |
 | `--top-k` | `8` | RAG-Chunks pro Prüffrage |
+| `--review-budget` | — | Stoppt nach N review-markierten Befunden und schreibt Checkpoint-Metadaten |
 | `--skeptiker` | aus | Skeptiker-Agent aktivieren |
 | `--skeptiker-only-konform` | aus | Skeptiker nur für `konform`-Ratings |
 | `--adversarial` | aus | Adversarial Prompting Layer aktivieren |
@@ -726,7 +727,7 @@ Hinweise:
 - [ ] Disagreement Resolution Protocol: `disputed`-Status + eigener Report-Abschnitt bei Prüfer-vs-Adversarial-Widerspruch *(Issue #2)*
 - [ ] Context Drift Detection: Regulatory Term Preservation Layer in `bericht_generator.py` *(Issue #3)*
 - [ ] Per-Claim Provenance + Skeptic-Tagging: Claim-Level-Annotation mit Corroboration-Status *(Issue #6)*
-- [ ] Human Validation Cadence: `--review-budget N` Flag + Checkpoint-Resume *(Issue #1)*
+- [x] ~~Human Validation Cadence: `--review-budget N` Flag + Checkpoint-Resume~~ ✅ *v2.5 – Issue #1*
 - [ ] Multi-Model Cross-Validation: Adversarial Reviewer mit Gemini / Grok für Confidence 0.40–0.70 *(Issue #5)*
 - [ ] Synthetische Kontroll-Prüffelder (Ground-Truth-Signal) zur Kalibrierung
 - [ ] Persistenter Vektorindex via ChromaDB / Weaviate

--- a/pipeline.py
+++ b/pipeline.py
@@ -88,6 +88,7 @@ class AuditPipeline:
         top_k: int = 8,
         verbose: bool = True,
         verbose_token_details: bool = False,
+        review_budget: int | None = None,
         skeptiker: bool = False,
         skeptiker_only_konform: bool = False,
         adversarial: bool = False,
@@ -104,8 +105,11 @@ class AuditPipeline:
         self.top_k = top_k
         self.verbose = verbose
         self.verbose_token_details = verbose_token_details
+        self.review_budget = review_budget
         self.skeptiker = skeptiker
         self.skeptiker_only_konform = skeptiker_only_konform
+        if self.review_budget is not None and self.review_budget < 1:
+            raise ValueError("review_budget muss >= 1 sein")
         self.run_token_stats = {
             "version": "1.0",
             "gesamt": {"input": 0, "output": 0, "total": 0},
@@ -116,15 +120,6 @@ class AuditPipeline:
             "details": [],
         }
         self.adversarial = adversarial
-        self.run_token_stats = {
-            "version": "1.0",
-            "gesamt": {"input": 0, "output": 0, "total": 0},
-            "nach_agent": {
-                "pruefer": {"input": 0, "output": 0, "total": 0},
-                "skeptiker": {"input": 0, "output": 0, "total": 0},
-            },
-            "details": [],
-        }
 
         # Katalogpfad auflösen
         base = Path(__file__).parent
@@ -221,6 +216,8 @@ class AuditPipeline:
         sektionsergebnisse = []
         total_felder = 0
         gepruefte_felder = 0
+        review_markierte_felder = 0
+        review_budget_erreicht = False
         checkpoint_dir = Path(self.output_dir) / ".checkpoints"
         checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
@@ -261,7 +258,6 @@ class AuditPipeline:
                 self._log(
                     f"       → {status_icon} {befund.bewertung.value.upper()}{conf_str}{review_str} ({dauer:.1f}s)"
                 )
-                self._add_detail_stat(sektion["id"], feld["id"], befund)
 
                 if befund.validierungshinweise:
                     for hint in befund.validierungshinweise:
@@ -287,8 +283,21 @@ class AuditPipeline:
                     befund = merge_befund_skeptiker(befund, skeptiker_result)
                     self._add_token_usage("skeptiker", skeptiker_result.token_usage)
 
+                self._add_detail_stat(sektion["id"], feld["id"], befund)
                 ergebnis.befunde.append(befund)
                 gepruefte_felder += 1
+                if befund.review_erforderlich:
+                    review_markierte_felder += 1
+                    if (
+                        self.review_budget is not None
+                        and review_markierte_felder >= self.review_budget
+                    ):
+                        review_budget_erreicht = True
+                        self._log(
+                            f"  ⏸️ Review-Budget erreicht ({review_markierte_felder}/{self.review_budget}). "
+                            "Lauf wird nach dieser Sektion pausiert."
+                        )
+                        break
 
             # Sektions-Eskalation prüfen
             if ergebnis.review_quote >= SEKTION_REVIEW_ESCALATION:
@@ -299,7 +308,15 @@ class AuditPipeline:
             sektionsergebnisse.append(ergebnis)
 
             # Checkpoint: Zwischenergebnis sichern
-            self._save_checkpoint(sektionsergebnisse, checkpoint_dir)
+            self._save_checkpoint(
+                sektionsergebnisse,
+                checkpoint_dir,
+                review_budget=self.review_budget,
+                review_markierte_felder=review_markierte_felder,
+                review_budget_erreicht=review_budget_erreicht,
+            )
+            if review_budget_erreicht:
+                break
 
         if gepruefte_felder == 0:
             raise ValueError(
@@ -331,13 +348,25 @@ class AuditPipeline:
         self._log(f"✅ Prüfung abgeschlossen in {t_total:.0f}s")
         self._log(f"   Regulatorik: {label}")
         self._log(f"   Prüffelder:  {gepruefte_felder}/{total_felder}")
+        if self.review_budget is not None:
+            self._log(
+                f"   Review-Budget: {review_markierte_felder}/{self.review_budget} "
+                f"(erreicht={review_budget_erreicht})"
+            )
         self._log("   Berichte:")
         for fmt, pth in report_paths.items():
             self._log(f"     {fmt.upper()}: {pth}")
 
         return report_paths
 
-    def _save_checkpoint(self, sektionsergebnisse: list, checkpoint_dir: Path):
+    def _save_checkpoint(
+        self,
+        sektionsergebnisse: list,
+        checkpoint_dir: Path,
+        review_budget: int | None = None,
+        review_markierte_felder: int = 0,
+        review_budget_erreicht: bool = False,
+    ):
         """Sichert Zwischenergebnisse nach jeder Sektion."""
         try:
             data = []
@@ -362,6 +391,18 @@ class AuditPipeline:
             path.write_text(
                 json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
             )
+            if review_budget is not None:
+                meta_path = checkpoint_dir / "checkpoint_meta.json"
+                meta_payload = {
+                    "review_budget": review_budget,
+                    "review_markierte_felder": review_markierte_felder,
+                    "review_budget_erreicht": review_budget_erreicht,
+                    "fortsetzung_erforderlich": review_budget_erreicht,
+                }
+                meta_path.write_text(
+                    json.dumps(meta_payload, indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
         except Exception as e:
             logger.warning("Checkpoint-Fehler (Pipeline läuft weiter): %s", e)
 
@@ -549,6 +590,12 @@ Beispiele:
     )
     parser.add_argument("--top-k", type=int, default=8, help="RAG-Chunks pro Prüffrage")
     parser.add_argument(
+        "--review-budget",
+        type=int,
+        default=None,
+        help="Stoppt den Lauf nach N review-markierten Befunden und schreibt einen Checkpoint.",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         default=False,
@@ -603,6 +650,7 @@ Beispiele:
         top_k=args.top_k,
         verbose=not args.quiet,
         verbose_token_details=args.verbose,
+        review_budget=args.review_budget,
         skeptiker=args.skeptiker,
         skeptiker_only_konform=args.skeptiker_only_konform,
         adversarial=args.adversarial,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -621,6 +621,75 @@ class TestPipelineScopeValidation:
         with pytest.raises(ValueError, match="Keine Prüffelder wurden verarbeitet"):
             pipeline.run()
 
+    @patch("pipeline.BerichtGenerator")
+    @patch("pipeline.PrueferAgent")
+    @patch("pipeline.VectorStoreIndex")
+    @patch("pipeline.build_embedding")
+    @patch("pipeline.Settings")
+    @patch("pipeline.GwGIngestor")
+    def test_run_stops_at_review_budget_and_writes_checkpoint_meta(
+        self,
+        mock_ingestor_cls,
+        mock_settings,
+        _mock_embedding,
+        mock_vector_store_index,
+        mock_pruefer_cls,
+        mock_bericht_cls,
+        tmp_path,
+    ):
+        mock_ingestor = MagicMock()
+        mock_ingestor.ingest_directory.return_value = [object()]
+        mock_ingestor_cls.return_value = mock_ingestor
+        mock_vector_store_index.from_documents.return_value = MagicMock()
+        mock_settings.embed_model = None
+
+        befund = Befund(
+            prueffeld_id="GWG-S01-01",
+            frage="Testfrage",
+            bewertung=Bewertung.KONFORM,
+            begruendung="ok",
+            belegte_textstellen=["beleg"],
+            confidence=0.7,
+            confidence_level="medium",
+            confidence_guards={},
+            low_confidence_reasons=[],
+            token_usage={"input": 10, "output": 5, "total": 15},
+            review_erforderlich=True,
+            validierungshinweise=[],
+        )
+        mock_pruefer = MagicMock()
+        mock_pruefer.pruefe_feld.return_value = befund
+        mock_pruefer_cls.return_value = mock_pruefer
+
+        mock_bericht = MagicMock()
+        mock_bericht.generiere_alle_berichte.return_value = {
+            "json": "a.json",
+            "markdown": "a.md",
+            "html": "a.html",
+        }
+        mock_bericht_cls.return_value = mock_bericht
+
+        pipeline = AuditPipeline(
+            input_dir="demo",
+            output_dir=str(tmp_path),
+            regulatorik="gwg",
+            review_budget=1,
+            verbose=False,
+        )
+        pipeline.run()
+
+        assert mock_pruefer.pruefe_feld.call_count == 1
+        meta_path = tmp_path / ".checkpoints" / "checkpoint_meta.json"
+        assert meta_path.exists()
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["review_budget"] == 1
+        assert meta["review_markierte_felder"] == 1
+        assert meta["review_budget_erreicht"] is True
+
+    def test_review_budget_must_be_positive(self):
+        with pytest.raises(ValueError, match="review_budget muss >= 1 sein"):
+            AuditPipeline(input_dir="demo", review_budget=0)
+
 
 class TestTokenStats:
     def test_write_run_stats_contains_required_fields(self, tmp_path):


### PR DESCRIPTION
Implements Issue #1 (Human Validation Cadence).\n\n## Was ist neu\n- Neuer Pipeline-Parameter und CLI-Flag: --review-budget N\n- Lauf pausiert nach N review-markierten Befunden\n- Checkpoint-Metadaten unter .checkpoints/checkpoint_meta.json\n  - review_budget\n  - review_markierte_felder\n  - review_budget_erreicht\n  - fortsetzung_erforderlich\n- Detailstatistiken werden nach Skeptiker-Merge erfasst (konsistenter Endzustand)\n- README: CLI-Doku ergänzt, Roadmap-Eintrag für Issue #1 auf erledigt gesetzt\n\n## Tests\n- test_run_stops_at_review_budget_and_writes_checkpoint_meta\n- test_review_budget_must_be_positive\n\nLokal validiert:\n- ruff check .\n- ruff format --check .\n- pytest -q (80 passed)\n\nCloses #1