### PR TITLE
feat: implement disputed status and disagreement reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ Hinweise:
 
 - [x] ~~Skeptiker-Agent: Adversariales LLM-Review als optionaler Post-Processing-Layer~~ ✅ *v2.1*
 - [x] ~~Adversarial Prompting Layer: zweiter LLM-Pass mit umgekehrtem System-Prompt~~ ✅ *v2.2 – Issue #4*
-- [ ] Disagreement Resolution Protocol: `disputed`-Status + eigener Report-Abschnitt bei Prüfer-vs-Adversarial-Widerspruch *(Issue #2)*
+- [x] ~~Disagreement Resolution Protocol: `disputed`-Status + eigener Report-Abschnitt bei Prüfer-vs-Adversarial-Widerspruch~~ ✅ *v2.6 – Issue #2*
 - [ ] Context Drift Detection: Regulatory Term Preservation Layer in `bericht_generator.py` *(Issue #3)*
 - [ ] Per-Claim Provenance + Skeptic-Tagging: Claim-Level-Annotation mit Corroboration-Status *(Issue #6)*
 - [x] ~~Human Validation Cadence: `--review-budget N` Flag + Checkpoint-Resume~~ ✅ *v2.5 – Issue #1*

--- a/agents/pruef_agent.py
+++ b/agents/pruef_agent.py
@@ -37,6 +37,7 @@ class Bewertung(str, Enum):
     TEILKONFORM = "teilkonform"
     NICHT_KONFORM = "nicht_konform"
     NICHT_PRUEFBAR = "nicht_prüfbar"
+    DISPUTED = "disputed"
 
 
 class Schweregrad(str, Enum):
@@ -192,6 +193,7 @@ BEWERTUNG_SEVERITY = {
     "teilkonform": 1,
     "nicht_konform": 2,
     "nicht_prüfbar": 3,
+    "disputed": 3,
 }
 
 # Confidence-Penalty je Divergenzstufe

--- a/agents/skeptiker_agent.py
+++ b/agents/skeptiker_agent.py
@@ -487,11 +487,15 @@ def merge_befund_skeptiker(befund: Befund, skeptiker: SkeptikerBefund) -> Befund
         or not skeptiker.akzeptiert
         or len(skeptiker.einwaende) >= EINWAND_ESKALATION_THRESHOLD
     )
+    disputed = not skeptiker.akzeptiert and (
+        skeptiker.bewertung_empfehlung is None
+        or skeptiker.bewertung_empfehlung != befund.bewertung
+    )
 
     return Befund(
         prueffeld_id=befund.prueffeld_id,
         frage=befund.frage,
-        bewertung=befund.bewertung,  # Originalbewertung behalten!
+        bewertung=Bewertung.DISPUTED if disputed else befund.bewertung,
         begruendung=befund.begruendung,
         belegte_textstellen=befund.belegte_textstellen,
         empfehlungen=befund.empfehlungen,

--- a/pipeline.py
+++ b/pipeline.py
@@ -249,6 +249,7 @@ class AuditPipeline:
                     "teilkonform": "⚠️",
                     "nicht_konform": "🔴",
                     "nicht_prüfbar": "❓",
+                    "disputed": "⚖️",
                 }.get(befund.bewertung.value, "?")
 
                 conf_str = (

--- a/reports/bericht_generator.py
+++ b/reports/bericht_generator.py
@@ -33,6 +33,7 @@ BEWERTUNG_STYLE = {
     "teilkonform": {"emoji": "⚠️", "color": "#e67e22", "bg": "#fef9e7"},
     "nicht_konform": {"emoji": "🔴", "color": "#c0392b", "bg": "#fdedec"},
     "nicht_prüfbar": {"emoji": "❓", "color": "#7f8c8d", "bg": "#f2f3f4"},
+    "disputed": {"emoji": "⚖️", "color": "#8e44ad", "bg": "#f4ecf7"},
 }
 
 SCHWEREGRAD_STYLE = {
@@ -163,12 +164,15 @@ class BerichtGenerator:
         nicht_pruefbar = [
             b for b in alle_befunde if b.bewertung.value == "nicht_prüfbar"
         ]
+        strittig = [b for b in alle_befunde if b.bewertung.value == "disputed"]
         review_nötig = [b for b in alle_befunde if b.review_erforderlich]
 
         wesentliche_mängel = [b for b in mängel if b.schweregrad == "wesentlich"]
 
         total = len(alle_befunde)
-        np_quote = len(nicht_pruefbar) / total if total else 0
+        gewertet = max(0, total - len(strittig))
+        unresolved = len(nicht_pruefbar) + len(strittig)
+        np_quote = unresolved / gewertet if gewertet else 1.0
 
         # Confidence-Statistiken
         confidences = [b.confidence for b in alle_befunde]
@@ -198,10 +202,12 @@ class BerichtGenerator:
             "gesamtbewertung": gesamtbewertung,
             "gesamtfarbe": gesamtfarbe,
             "total_prueffelder": total,
+            "gewertete_prueffelder": gewertet,
             "konform": bewertungs_zähler.get("konform", 0),
             "teilkonform": bewertungs_zähler.get("teilkonform", 0),
             "nicht_konform": bewertungs_zähler.get("nicht_konform", 0),
             "nicht_pruefbar": bewertungs_zähler.get("nicht_prüfbar", 0),
+            "disputed": bewertungs_zähler.get("disputed", 0),
             "nicht_pruefbar_quote": round(np_quote * 100, 1),
             "review_erforderlich": len(review_nötig),
             "avg_confidence": round(avg_confidence, 3),
@@ -218,6 +224,21 @@ class BerichtGenerator:
                     mängel + teilkonform,
                     key=lambda x: 0 if x.schweregrad == "wesentlich" else 1,
                 )
+            ],
+            "strittige_befunde": [
+                {
+                    "id": b.prueffeld_id,
+                    "frage": b.frage,
+                    "empfehlung": next(
+                        (
+                            h.split("'")[1]
+                            for h in b.validierungshinweise
+                            if "Skeptiker widerspricht" in h and "'" in h
+                        ),
+                        "unklar",
+                    ),
+                }
+                for b in strittig
             ],
             "audit_trail": {
                 "modell": self.model,
@@ -322,7 +343,9 @@ class BerichtGenerator:
             f"| ⚠️ Teilkonform | {z['teilkonform']} |",
             f"| 🔴 Nicht konform | {z['nicht_konform']} |",
             f"| ❓ Nicht prüfbar | {z['nicht_pruefbar']} ({z['nicht_pruefbar_quote']}%) |",
+            f"| ⚖️ Strittig (disputed) | {z['disputed']} |",
             f"| **Gesamt** | **{z['total_prueffelder']}** |",
+            f"| **Gewertet** | **{z['gewertete_prueffelder']}** |",
             f"| 🔍 Review erforderlich | {z['review_erforderlich']} |",
             "",
         ]
@@ -358,6 +381,17 @@ class BerichtGenerator:
             for m in z["kritische_befunde"]:
                 sg = (m.get("schweregrad") or "").upper()
                 lines.append(f"- **[{m['id']}] [{sg}]** {m['mangel'] or m['frage']}")
+            lines.append("")
+
+        if z["strittige_befunde"]:
+            lines += [
+                f"## Strittige Befunde ({len(z['strittige_befunde'])})",
+                "",
+            ]
+            for s in z["strittige_befunde"]:
+                lines.append(
+                    f"- **[{s['id']}]** {s['frage']} *(Skeptiker-Empfehlung: {s['empfehlung']})*"
+                )
             lines.append("")
 
         lines.append("---")
@@ -504,7 +538,7 @@ class BerichtGenerator:
   .gesamtbewertung {{ padding: 16px 20px; border-radius: 8px; margin-bottom: 24px;
                       font-weight: 700; font-size: 16px; border-left: 5px solid {z["gesamtfarbe"]};
                       background: {z["gesamtfarbe"]}15; color: {z["gesamtfarbe"]}; }}
-  .stats-grid {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+  .stats-grid {{ display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;
                  margin-bottom: 32px; }}
   .stat-card {{ padding: 16px; border-radius: 8px; text-align: center; border: 1px solid #ecf0f1; }}
   .stat-number {{ font-size: 28px; font-weight: 700; }}
@@ -596,6 +630,9 @@ class BerichtGenerator:
   <div class="stat-card" style="background:#fdedec;border-color:#fadbd8">
     <div class="stat-number" style="color:#c0392b">{z["nicht_konform"]}</div>
     <div class="stat-label">🔴 Nicht konform</div></div>
+  <div class="stat-card" style="background:#f4ecf7;border-color:#e8daef">
+    <div class="stat-number" style="color:#8e44ad">{z["disputed"]}</div>
+    <div class="stat-label">⚖️ Strittig</div></div>
   <div class="stat-card" style="background:#f2f3f4;border-color:#d5d8dc">
     <div class="stat-number" style="color:#7f8c8d">{z["nicht_pruefbar"]}</div>
     <div class="stat-label">❓ Nicht prüfbar ({z["nicht_pruefbar_quote"]}%)</div></div>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -455,6 +455,23 @@ class TestSkeptikerAgent:
         assert "Prozessnachweis fehlt" in hints
         assert "Audit-Trail" in hints
 
+    def test_merge_sets_disputed_when_skeptiker_disagrees(self):
+        befund = self._make_befund(bewertung=Bewertung.KONFORM, confidence=0.8)
+        skeptiker = SkeptikerBefund(
+            prueffeld_id="S01-01",
+            original_bewertung=Bewertung.KONFORM,
+            original_confidence=0.8,
+            akzeptiert=False,
+            bewertung_empfehlung=Bewertung.NICHT_KONFORM,
+            einwaende=["Wesentliche Kontrolllücke"],
+            adjustierter_confidence=0.5,
+        )
+
+        merged = merge_befund_skeptiker(befund, skeptiker)
+
+        assert merged.bewertung == Bewertung.DISPUTED
+        assert merged.review_erforderlich is True
+
     def test_skeptiker_befund_dataclass(self):
         """SkeptikerBefund kann instanziiert werden."""
         sb = SkeptikerBefund(
@@ -764,3 +781,32 @@ class TestBerichtGeneratorTokenStats:
         assert "Gesamt Tokens" in html
         assert "Pricing-Stand" in html
         assert "run_stats.json" in html
+
+    def test_summary_tracks_disputed_separately(self):
+        generator = BerichtGenerator()
+        sektion = Sektionsergebnis(sektion_id="S01", titel="Test")
+        sektion.befunde = [
+            Befund(
+                prueffeld_id="S01-01",
+                frage="?",
+                bewertung=Bewertung.KONFORM,
+                begruendung="ok",
+                confidence=0.8,
+            ),
+            Befund(
+                prueffeld_id="S01-02",
+                frage="?",
+                bewertung=Bewertung.DISPUTED,
+                begruendung="strittig",
+                confidence=0.6,
+                validierungshinweise=[
+                    "⚔️ Skeptiker widerspricht: Empfehlung 'nicht_konform'"
+                ],
+            ),
+        ]
+
+        z = generator._berechne_zusammenfassung([sektion])
+
+        assert z["disputed"] == 1
+        assert z["gewertete_prueffelder"] == 1
+        assert len(z["strittige_befunde"]) == 1


### PR DESCRIPTION
Implements Issue #2 (Disagreement Resolution Protocol).\n\n## Was ist neu\n- Neuer Bewertungsstatus: disputed\n- Bei Skeptiker-Widerspruch mit abweichender Empfehlung wird Befund als disputed markiert\n- disputed-Befunde bleiben review_erforderlich\n- Berichtszusammenfassung erweitert:\n  - disputed count\n  - gewertete_prueffelder\n  - strittige_befunde-Liste\n- Markdown/HTML-Zusammenfassung zeigt disputed explizit\n- Pipeline-Statusicon fuer disputed ergänzt\n\n## Tests\n- test_merge_sets_disputed_when_skeptiker_disagrees\n- test_summary_tracks_disputed_separately\n\nLokal validiert:\n- ruff check .\n- ruff format --check .\n- pytest -q (82 passed)\n\nCloses #2