### PR TITLE
feat: add context drift detection for norm references

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Hinweise:
 - [x] ~~Skeptiker-Agent: Adversariales LLM-Review als optionaler Post-Processing-Layer~~ ✅ *v2.1*
 - [x] ~~Adversarial Prompting Layer: zweiter LLM-Pass mit umgekehrtem System-Prompt~~ ✅ *v2.2 – Issue #4*
 - [x] ~~Disagreement Resolution Protocol: `disputed`-Status + eigener Report-Abschnitt bei Prüfer-vs-Adversarial-Widerspruch~~ ✅ *v2.6 – Issue #2*
-- [ ] Context Drift Detection: Regulatory Term Preservation Layer in `bericht_generator.py` *(Issue #3)*
+- [x] ~~Context Drift Detection: Regulatory Term Preservation Layer in `bericht_generator.py`~~ ✅ *v2.7 – Issue #3*
 - [ ] Per-Claim Provenance + Skeptic-Tagging: Claim-Level-Annotation mit Corroboration-Status *(Issue #6)*
 - [x] ~~Human Validation Cadence: `--review-budget N` Flag + Checkpoint-Resume~~ ✅ *v2.5 – Issue #1*
 - [ ] Multi-Model Cross-Validation: Adversarial Reviewer mit Gemini / Grok für Confidence 0.40–0.70 *(Issue #5)*

--- a/agents/pruef_agent.py
+++ b/agents/pruef_agent.py
@@ -355,12 +355,24 @@ KNOWN_LAW_PATTERNS = {
 GENERIC_LAW_REF_RE = re.compile(
     r"(§\s*\d+[a-z]?(?:\s+\S+){0,6}|Art\.\s*\d+[a-z]?(?:\s+\S+){0,6})"
 )
+NORM_REF_RE = re.compile(
+    r"(§\s*\d+[a-z]?(?:\s*Abs\.\s*\d+)?(?:\s*(?:GwG|KWG|WpHG|MaComp))?"
+    r"|Art\.\s*\d+[a-z]?(?:\s*Abs\.\s*\d+)?(?:\s*(?:DORA|MAR))?)"
+)
+
+
+def _extract_norm_refs(text: str) -> set[str]:
+    refs = set()
+    for match in NORM_REF_RE.finditer(text or ""):
+        refs.add(re.sub(r"\s+", " ", match.group(0).strip()))
+    return refs
 
 
 def validate_befund_structure(
     llm_result: dict,
     retrieved_sources: set[str],
     regulatorik: str,
+    evidence_text: str = "",
 ) -> list[str]:
     """
     Strukturelle Validierung des LLM-Outputs. Gibt eine Liste von Warnungen zurück.
@@ -416,6 +428,26 @@ def validate_befund_structure(
         if suspicious_refs:
             refs = ", ".join(sorted(suspicious_refs))
             warnings.append(f"Unplausible Rechtszitate für '{regulatorik}': {refs}")
+
+    # 7. Context-Drift: zentrale Normreferenzen aus Evidenz sollen erhalten bleiben
+    if evidence_text:
+        refs_evidence = _extract_norm_refs(evidence_text)
+        refs_befund = _extract_norm_refs(
+            " ".join(
+                [
+                    llm_result.get("begruendung", "") or "",
+                    llm_result.get("mangel_text", "") or "",
+                    " ".join(llm_result.get("belegte_textstellen", []) or []),
+                ]
+            )
+        )
+        missing_refs = refs_evidence - refs_befund
+        if missing_refs:
+            sample = ", ".join(sorted(missing_refs)[:3])
+            warnings.append(
+                "Context-Drift-Verdacht: Normreferenzen aus Evidenz fehlen im "
+                f"Befund ({sample})"
+            )
 
     return warnings
 
@@ -595,7 +627,10 @@ class PrueferAgent:
 
         # 5. Strukturelle Validierung
         val_warnings = validate_befund_structure(
-            llm_result, retrieved_sources, self.regulatorik
+            llm_result,
+            retrieved_sources,
+            self.regulatorik,
+            evidence_text=evidenz_text,
         )
 
         # 6. Confidence-Score berechnen

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -248,6 +248,34 @@ class TestStructuralValidation:
         )
         assert not any("Unplausible Rechtszitate" in w for w in warnings)
 
+    def test_context_drift_warning_when_norm_ref_missing(self):
+        warnings = validate_befund_structure(
+            llm_result={
+                "bewertung": "teilkonform",
+                "quellen": ["doc.pdf"],
+                "belegte_textstellen": ["Interne Sicherungsmaßnahmen sind vorhanden."],
+                "begruendung": "Es gibt Sicherungsmaßnahmen, Details bleiben unklar.",
+            },
+            retrieved_sources={"doc.pdf"},
+            regulatorik="gwg",
+            evidence_text="Evidenz mit § 15 Abs. 2 GwG und weiteren Details.",
+        )
+        assert any("Context-Drift-Verdacht" in w for w in warnings)
+
+    def test_context_drift_not_flagged_when_norm_ref_preserved(self):
+        warnings = validate_befund_structure(
+            llm_result={
+                "bewertung": "konform",
+                "quellen": ["doc.pdf"],
+                "belegte_textstellen": ["§ 15 Abs. 2 GwG wird umgesetzt."],
+                "begruendung": "Die Vorgaben aus § 15 Abs. 2 GwG sind erfüllt.",
+            },
+            retrieved_sources={"doc.pdf"},
+            regulatorik="gwg",
+            evidence_text="Evidenz mit § 15 Abs. 2 GwG und Umsetzungsbeschreibung.",
+        )
+        assert not any("Context-Drift-Verdacht" in w for w in warnings)
+
 
 # ------------------------------------------------------------------ #
 # Test: Sektionsergebnis


### PR DESCRIPTION
Implements Issue #3 (Context Drift Detection).\n\n## Was ist neu\n- Neue Normreferenz-Extraktion in PrueferAgent-Validierung\n- Context-Drift-Warnung wenn Normzitate aus Evidenz im Befund fehlen\n- Integration in validate_befund_structure(..., evidence_text=...)\n- Zusatztests fuer Drift-Warnung (positiv/negativ)\n- README-Roadmap fuer Issue #3 auf erledigt gesetzt\n\n## Tests\n- test_context_drift_warning_when_norm_ref_missing\n- test_context_drift_not_flagged_when_norm_ref_preserved\n\nLokal validiert:\n- ruff check .\n- ruff format --check .\n- pytest -q (82 passed)\n\nCloses #3