### PR TITLE
feat: add GitHub App template for multi-bot PR routing

### DIFF
--- a/.github/workflows/bot-router.yml
+++ b/.github/workflows/bot-router.yml
@@ -8,7 +8,7 @@ on:
       pr_number:
         description: "Pull Request number"
         required: true
-        type: string
+        type: number
       bot:
         description: "Target bot"
         required: true
@@ -27,39 +27,66 @@ jobs:
   route:
     if: github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
+      - name: Validate pr_number input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if ! [[ "${{ github.event.inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be numeric"
+            exit 1
+          fi
+
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1 # v1
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v1.11.6
         with:
           app-id: ${{ secrets.FINREG_APP_ID }}
           private-key: ${{ secrets.FINREG_APP_PRIVATE_KEY }}
 
       - name: Resolve target bot
         id: bot
-        uses: actions/github-script@v7 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            if (context.eventName === "workflow_dispatch") {
-              core.setOutput("name", "${{ github.event.inputs.bot }}");
-              core.setOutput("pr_number", "${{ github.event.inputs.pr_number }}");
-              return;
-            }
-
-            const labels = context.payload.pull_request.labels.map((l) => l.name.toLowerCase());
             const map = {
               "bot:codex": "codex",
               "bot:claude": "claude",
               "bot:gemini": "gemini",
             };
 
-            const selected = labels.find((label) => map[label]);
-            if (!selected) {
+            if (context.eventName === "workflow_dispatch") {
+              const inputs = context.payload.inputs || {};
+              const bot = String(inputs.bot || "");
+              const prNumber = Number(String(inputs.pr_number || ""));
+              if (!["codex", "claude", "gemini"].includes(bot)) {
+                core.setFailed(`Unsupported bot value: ${bot}`);
+                return;
+              }
+              if (!Number.isInteger(prNumber) || prNumber <= 0) {
+                core.setFailed(`Invalid pr_number: ${inputs.pr_number}`);
+                return;
+              }
+              core.setOutput("name", bot);
+              core.setOutput("pr_number", String(prNumber));
+              return;
+            }
+
+            const labels = context.payload.pull_request.labels.map((l) => l.name.toLowerCase());
+            const selected = labels.filter((label) => map[label]);
+            if (selected.length > 1) {
+              core.setFailed(`Mehrere Bot-Labels gefunden: ${selected.join(", ")}. Bitte nur eines setzen.`);
+              return;
+            }
+            if (selected.length === 0) {
               core.info("No bot label found (expected: bot:codex, bot:claude, bot:gemini).");
               core.setOutput("name", "");
             } else {
-              core.setOutput("name", map[selected]);
+              core.setOutput("name", map[selected[0]]);
             }
             core.setOutput("pr_number", String(context.payload.pull_request.number));
 
@@ -69,12 +96,25 @@ jobs:
 
       - name: Dispatch bot request
         if: steps.bot.outputs.name != ''
-        uses: actions/github-script@v7 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = Number("${{ steps.bot.outputs.pr_number }}");
             const bot = "${{ steps.bot.outputs.name }}";
+            let headRef = "";
+
+            if (context.eventName === "pull_request_target") {
+              headRef = context.payload.pull_request.head.ref;
+            } else {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              headRef = pr.data.head.ref;
+            }
+
             await github.request("POST /repos/{owner}/{repo}/dispatches", {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -82,13 +122,14 @@ jobs:
               client_payload: {
                 pr_number: prNumber,
                 bot: bot,
-                sender: context.actor
+                sender: context.actor,
+                head_ref: headRef
               }
             });
 
       - name: Post PR comment
         if: steps.bot.outputs.name != '' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v7 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -99,3 +140,9 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: `Bot routing aktiv: **${bot}** wurde angefordert.\n\nNächster Schritt: Worker-Workflow verarbeitet \`repository_dispatch:bot_requested\`.`
             });
+
+      - name: Workflow dispatch summary
+        if: steps.bot.outputs.name != '' && github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Bot routing aktiv: ${{ steps.bot.outputs.name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "PR #${{ steps.bot.outputs.pr_number }} wurde an den Worker dispatcht." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bot-router.yml
+++ b/.github/workflows/bot-router.yml
@@ -1,0 +1,101 @@
+name: Bot Router (GitHub App)
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull Request number"
+        required: true
+        type: string
+      bot:
+        description: "Target bot"
+        required: true
+        type: choice
+        options:
+          - codex
+          - claude
+          - gemini
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  route:
+    if: github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1 # v1
+        with:
+          app-id: ${{ secrets.FINREG_APP_ID }}
+          private-key: ${{ secrets.FINREG_APP_PRIVATE_KEY }}
+
+      - name: Resolve target bot
+        id: bot
+        uses: actions/github-script@v7 # v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            if (context.eventName === "workflow_dispatch") {
+              core.setOutput("name", "${{ github.event.inputs.bot }}");
+              core.setOutput("pr_number", "${{ github.event.inputs.pr_number }}");
+              return;
+            }
+
+            const labels = context.payload.pull_request.labels.map((l) => l.name.toLowerCase());
+            const map = {
+              "bot:codex": "codex",
+              "bot:claude": "claude",
+              "bot:gemini": "gemini",
+            };
+
+            const selected = labels.find((label) => map[label]);
+            if (!selected) {
+              core.info("No bot label found (expected: bot:codex, bot:claude, bot:gemini).");
+              core.setOutput("name", "");
+            } else {
+              core.setOutput("name", map[selected]);
+            }
+            core.setOutput("pr_number", String(context.payload.pull_request.number));
+
+      - name: Skip when no bot label is set
+        if: steps.bot.outputs.name == ''
+        run: echo "No bot selected. Add one label: bot:codex, bot:claude or bot:gemini."
+
+      - name: Dispatch bot request
+        if: steps.bot.outputs.name != ''
+        uses: actions/github-script@v7 # v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const prNumber = Number("${{ steps.bot.outputs.pr_number }}");
+            const bot = "${{ steps.bot.outputs.name }}";
+            await github.request("POST /repos/{owner}/{repo}/dispatches", {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: "bot_requested",
+              client_payload: {
+                pr_number: prNumber,
+                bot: bot,
+                sender: context.actor
+              }
+            });
+
+      - name: Post PR comment
+        if: steps.bot.outputs.name != '' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v7 # v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const bot = "${{ steps.bot.outputs.name }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Bot routing aktiv: **${bot}** wurde angefordert.\n\nNächster Schritt: Worker-Workflow verarbeitet \`repository_dispatch:bot_requested\`.`
+            });

--- a/.github/workflows/bot-worker-template.yml
+++ b/.github/workflows/bot-worker-template.yml
@@ -1,0 +1,51 @@
+name: Bot Worker (Template)
+
+on:
+  repository_dispatch:
+    types: [bot_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  worker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1 # v1
+        with:
+          app-id: ${{ secrets.FINREG_APP_ID }}
+          private-key: ${{ secrets.FINREG_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Show payload
+        run: |
+          echo "Bot: ${{ github.event.client_payload.bot }}"
+          echo "PR: ${{ github.event.client_payload.pr_number }}"
+          echo "Sender: ${{ github.event.client_payload.sender }}"
+
+      - name: Execute Codex template
+        if: github.event.client_payload.bot == 'codex'
+        run: |
+          echo "TODO: Codex-Automation hier einbauen."
+          echo "Beispiel: Lint/Fix laufen lassen und Commit vorbereiten."
+
+      - name: Execute Claude template
+        if: github.event.client_payload.bot == 'claude'
+        run: |
+          echo "TODO: Claude-Review-Automation hier einbauen."
+          echo "Beispiel: Review-Zusammenfassung als PR-Kommentar posten."
+
+      - name: Execute Gemini template
+        if: github.event.client_payload.bot == 'gemini'
+        run: |
+          echo "TODO: Gemini-Doku-Automation hier einbauen."
+          echo "Beispiel: README/Changelog Checks und Kommentar posten."

--- a/.github/workflows/bot-worker-template.yml
+++ b/.github/workflows/bot-worker-template.yml
@@ -12,18 +12,23 @@ permissions:
 jobs:
   worker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1 # v1
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v1.11.6
         with:
           app-id: ${{ secrets.FINREG_APP_ID }}
           private-key: ${{ secrets.FINREG_APP_PRIVATE_KEY }}
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.client_payload.head_ref }}
           fetch-depth: 0
 
       - name: Show payload

--- a/docs/github-app-bot-template.md
+++ b/docs/github-app-bot-template.md
@@ -1,0 +1,46 @@
+# GitHub App Template fuer Multi-Bot-Setup
+
+Dieses Template richtet ein label-gesteuertes Routing fuer `codex`, `claude` und `gemini` ein.
+
+## Enthaltene Workflows
+
+- `.github/workflows/bot-router.yml`
+- `.github/workflows/bot-worker-template.yml`
+
+## Prinzip
+
+1. Auf einem PR wird ein Label gesetzt: `bot:codex`, `bot:claude` oder `bot:gemini`.
+2. `bot-router.yml` erstellt ein GitHub-App-Token und dispatcht `repository_dispatch` mit Payload.
+3. `bot-worker-template.yml` nimmt das Event entgegen und fuehrt den passenden Bot-Zweig aus.
+
+## GitHub App Setup
+
+1. GitHub App in der Organisation/User erstellen.
+2. Berechtigungen setzen:
+- `Contents`: Read/Write (nur wenn Bots Commits pushen sollen)
+- `Pull requests`: Read/Write
+- `Issues`: Read/Write
+- `Metadata`: Read
+3. App im Repo `endvater/finreg-agents` installieren.
+4. Secrets im Repo hinterlegen:
+- `FINREG_APP_ID`
+- `FINREG_APP_PRIVATE_KEY`
+
+## Labels
+
+Einmalig im Repo anlegen:
+
+- `bot:codex`
+- `bot:claude`
+- `bot:gemini`
+
+## Manuelle Ausloesung
+
+`bot-router.yml` kann ueber `workflow_dispatch` gestartet werden:
+
+- `pr_number`: PR-Nummer
+- `bot`: `codex|claude|gemini`
+
+## Naechster Schritt
+
+Im Worker-Template die drei TODO-Bloecke durch echte Bot-Aufrufe ersetzen (z. B. ueber CLI/MCP/HTTP).


### PR DESCRIPTION
Dieses PR fuegt ein startbereites Template fuer ein GitHub-App-basiertes Multi-Bot-Setup hinzu (Codex/Claude/Gemini).

Enthalten:
- .github/workflows/bot-router.yml
  - Label-gesteuertes Routing (bot:codex, bot:claude, bot:gemini)
  - erstellt GitHub-App-Token und dispatcht repository_dispatch
  - optional manuelle Ausloesung via workflow_dispatch
- .github/workflows/bot-worker-template.yml
  - Worker-Template fuer repository_dispatch: bot_requested
  - drei getrennte TODO-Zweige fuer Codex/Claude/Gemini
- docs/github-app-bot-template.md
  - Setup-Anleitung (App-Permissions, Secrets, Labels, naechste Schritte)

Benoetigte Repo-Secrets:
- FINREG_APP_ID
- FINREG_APP_PRIVATE_KEY

Hinweis:
- Das ist bewusst ein Template-PR ohne provider-spezifische Bot-Implementierung. Die TODO-Bloecke im Worker sind fuer eure konkrete Integration gedacht.